### PR TITLE
Cost-saving mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -184,6 +184,7 @@ def lambda_handler(event, context):
     region = os.environ["AWS_REGION"]
 
     cost_saving_mode = event.get("cost_saving_mode", False)
+    toggling_cost_saving_mode = event.get("toggling_cost_saving_mode", False)
     s3_bucket = event.get("s3_bucket", "")
     s3_key = event.get("s3_key", "")
     if s3_bucket and s3_key:
@@ -218,6 +219,7 @@ def lambda_handler(event, context):
         {
             "content": s3_path_of_aws_repository_zip,
             "cost_saving_mode": cost_saving_mode,
+            "toggling_cost_saving_mode": toggling_cost_saving_mode,
         }
     )
     start_pipeline_execution(pipeline_arn, execution_name, execution_input)

--- a/src/main.py
+++ b/src/main.py
@@ -188,7 +188,6 @@ def lambda_handler(event, context):
     s3_bucket = event.get("s3_bucket", "")
     s3_key = event.get("s3_key", "")
     if s3_bucket and s3_key:
-        logger.info("Lambda was triggered by CloudWatch Event")
         logger.info(
             "Path to trigger file was manually passed in to Lambda 's3://%s/%s'",
             s3_bucket,


### PR DESCRIPTION
Adds four optional inputs to the Lambda that are sent in when triggered by a CloudWatch Event:
`cost_saving_mode`, `toggling_cost_saving_mode`, `s3_bucket` and `s3_key`.

If the Lambda is triggered by an S3 Event instead, these inputs are set to default values and does not affect the CD pipeline's standard mode of execution.