### PR TITLE
Only allow certain branches to trigger the pipeline

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,13 @@ resource "aws_lambda_function" "infra_trigger_pipeline" {
   runtime          = "python3.7"
   filename         = data.archive_file.lambda_infra_trigger_pipeline_src.output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_infra_trigger_pipeline_src.output_path)
-  timeout          = var.lambda_timeout
-  tags             = var.tags
+  environment {
+    variables = {
+      ALLOWED_BRANCHES = jsonencode(var.allowed_branches)
+    }
+  }
+  timeout = var.lambda_timeout
+  tags    = var.tags
 }
 
 resource "aws_iam_role" "lambda_infra_trigger_pipeline_exec" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "statemachine_arn" {
   type        = string
 }
 
+variable "allowed_branches" {
+  description = "The branches that are allowed to trigger the AWS Step Functions pipeline."
+  default     = ["master"]
+}
+
 variable "additional_state_machine_arns" {
   description = "A list of ARNs of additional state machines that the Lambda can trigger"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "statemachine_arn" {
 }
 
 variable "allowed_branches" {
-  description = "The branches that are allowed to trigger the AWS Step Functions pipeline."
+  description = "The branches that are allowed to trigger an AWS Step Functions pipeline."
   default     = ["master"]
 }
 


### PR DESCRIPTION
A temporary fix for https://github.com/nsbno/teaminfrastruktur-backlog/issues/73 to avoid the pipeline accidentally being triggered from the wrong branches.