### PR TITLE
Disable retries for failed invocations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,11 @@ resource "aws_lambda_function" "infra_trigger_pipeline" {
   tags    = var.tags
 }
 
+resource "aws_lambda_function_event_invoke_config" "this" {
+  function_name          = aws_lambda_function.infra_trigger_pipeline.function_name
+  maximum_retry_attempts = 0
+}
+
 resource "aws_iam_role" "lambda_infra_trigger_pipeline_exec" {
   name               = "${var.name_prefix}-infra-trigger-pipeline"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume.json


### PR DESCRIPTION
Default Lambda behavior is to retry a failed Lambda up to 2 times. With our pipeline setup, this can lead to issues with multiple Step Functions executions being triggered within a short period of time, resulting in race conditions, Terraform lock issues, etc.

This PR disables retries for the Lambda. A future improvement may be to post a message to Slack if the actual trigger mechanism fails.