### PR TITLE
Add trigger rules and use new trigger-event.json format

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,15 +2,15 @@ data "aws_caller_identity" "current-account" {}
 data "aws_region" "current" {}
 
 locals {
-  current_account_id   = data.aws_caller_identity.current-account.account_id
-  current_region       = data.aws_region.current.name
-  name_of_trigger_file = "trigger-event.json"
-  trigger_rules_by_pipeline = { for obj in var.trigger_rules : obj.state_machine_arn => obj if var.trigger_rules != null }
-  trigger_rules = [for arn in var.state_machine_arns : lookup(local.trigger_rules_by_pipeline, state_machine_arn, {
+  current_account_id        = data.aws_caller_identity.current-account.account_id
+  current_region            = data.aws_region.current.name
+  name_of_trigger_file      = "trigger-event.json"
+  trigger_rules_by_pipeline = var.trigger_rules == null ? {} : { for obj in var.trigger_rules : obj.state_machine_arn => obj }
+  trigger_rules = [for arn in var.state_machine_arns : lookup(local.trigger_rules_by_pipeline, arn, {
     state_machine_arn    = arn
     allowed_branches     = var.allowed_branches
     allowed_repositories = ["*"]
-  }]
+  })]
 }
 
 data "archive_file" "lambda_infra_trigger_pipeline_src" {

--- a/main.tf
+++ b/main.tf
@@ -5,11 +5,12 @@ locals {
   current_account_id   = data.aws_caller_identity.current-account.account_id
   current_region       = data.aws_region.current.name
   name_of_trigger_file = "trigger-event.json"
-  trigger_rules = var.trigger_rules == null ? [for arn in var.state_machine_arns : {
+  trigger_rules_by_pipeline = { for obj in var.trigger_rules : obj.state_machine_arn => obj if var.trigger_rules != null }
+  trigger_rules = [for arn in var.state_machine_arns : lookup(local.trigger_rules_by_pipeline, state_machine_arn, {
     state_machine_arn    = arn
     allowed_branches     = var.allowed_branches
     allowed_repositories = ["*"]
-  }] : var.trigger_rules
+  }]
 }
 
 data "archive_file" "lambda_infra_trigger_pipeline_src" {

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
   current_account_id   = data.aws_caller_identity.current-account.account_id
   current_region       = data.aws_region.current.name
   name_of_trigger_file = "trigger-event.json"
+  state_machine_arns   = sort(distinct(concat([var.statemachine_arn], var.additional_state_machine_arns)))
   trigger_rules = var.trigger_rules == null ? [for arn in var.state_machine_arns : {
     state_machine_arn    = arn
     allowed_branches     = var.allowed_branches

--- a/main.tf
+++ b/main.tf
@@ -28,9 +28,9 @@ resource "aws_lambda_function" "infra_trigger_pipeline" {
   source_code_hash = filebase64sha256(data.archive_file.lambda_infra_trigger_pipeline_src.output_path)
   environment {
     variables = {
-      CURRENT_ACCOUNT_ID = local.current_account_id
-      TRIGGER_RULES      = jsonencode(local.trigger_rules)
-      NAME_OF_TRIGGER_FILE       = local.name_of_trigger_file
+      CURRENT_ACCOUNT_ID   = local.current_account_id
+      TRIGGER_RULES        = jsonencode(local.trigger_rules)
+      NAME_OF_TRIGGER_FILE = local.name_of_trigger_file
     }
   }
   timeout = var.lambda_timeout

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@ locals {
   current_account_id   = data.aws_caller_identity.current-account.account_id
   current_region       = data.aws_region.current.name
   name_of_trigger_file = "trigger-event.json"
-  state_machine_arns   = sort(distinct(concat([var.statemachine_arn], var.additional_state_machine_arns)))
   trigger_rules = var.trigger_rules == null ? [for arn in var.state_machine_arns : {
     state_machine_arn    = arn
     allowed_branches     = var.allowed_branches

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,8 @@ resource "aws_lambda_function" "infra_trigger_pipeline" {
   source_code_hash = filebase64sha256(data.archive_file.lambda_infra_trigger_pipeline_src.output_path)
   environment {
     variables = {
-      ALLOWED_BRANCHES = jsonencode(var.allowed_branches)
+      CURRENT_ACCOUNT_ID = local.current_account_id
+      ALLOWED_BRANCHES   = jsonencode(var.allowed_branches)
     }
   }
   timeout = var.lambda_timeout

--- a/policies.tf
+++ b/policies.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "stepfunctions_for_lambda" {
   statement {
     effect    = "Allow"
     actions   = ["states:StartExecution"]
-    resources = concat([var.statemachine_arn], var.additional_state_machine_arns)
+    resources = local.state_machine_arns
   }
 }
 

--- a/policies.tf
+++ b/policies.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "stepfunctions_for_lambda" {
   statement {
     effect    = "Allow"
     actions   = ["states:StartExecution"]
-    resources = local.state_machine_arns
+    resources = var.state_machine_arns
   }
 }
 

--- a/src/main.py
+++ b/src/main.py
@@ -178,7 +178,6 @@ def lambda_handler(event, context):
             **additional_inputs,
             **trigger_file,
             "deployment_package": deployment_package,
-            "content": deployment_package,
         }
     )
     if triggered_by_ci:

--- a/src/main.py
+++ b/src/main.py
@@ -180,7 +180,6 @@ def lambda_handler(event, context):
         }
     )
     if triggered_by_ci:
-        logger.info("Verifying rules %s", trigger_rules)
         rule = next(
             (
                 rule

--- a/src/main.py
+++ b/src/main.py
@@ -180,6 +180,7 @@ def lambda_handler(event, context):
         }
     )
     if triggered_by_ci:
+        logger.info("Verifying rules %s", trigger_rules)
         rule = next(
             (
                 rule["state_machine_arn"] == pipeline_arn

--- a/src/main.py
+++ b/src/main.py
@@ -105,7 +105,7 @@ def lambda_handler(event, context):
 
     allowed_branches = json.loads(os.environ["ALLOWED_BRANCHES"])
     region = os.environ["AWS_REGION"]
-    service_account_id = os.environ["SERVICE_ACCOUNT_ID"]
+    service_account_id = os.environ["CURRENT_ACCOUNT_ID"]
 
     cost_saving_mode = event.get("cost_saving_mode", False)
     toggling_cost_saving_mode = event.get("toggling_cost_saving_mode", False)

--- a/src/main.py
+++ b/src/main.py
@@ -66,7 +66,9 @@ def read_json_from_s3(s3_bucket, s3_key, expected_keys=[]):
         LookupError: Did not find expected keys in dictionary.
     """
     logger.debug(
-        "Reading file 's3://%s/%s", s3_bucket, s3_key,
+        "Reading file 's3://%s/%s",
+        s3_bucket,
+        s3_key,
     )
     try:
         s3 = boto3.resource("s3")
@@ -98,96 +100,12 @@ def read_json_from_s3(s3_bucket, s3_key, expected_keys=[]):
     return content
 
 
-def get_trigger_file_and_s3_path(s3_bucket, s3_key, allowed_branches):
-    """Gets the content of the trigger file belonging to the
-    GitHub repository containing the main AWS set up, as well
-    as the S3 path of the zip file containing the latest source
-    code for this repository.
-
-    Args:
-        s3_bucket: The name of the S3 bucket that triggered the Lambda.
-        s3_key: The S3 key of the file that triggered the Lambda.
-        allowed_branches: A list of allowed branches.
-
-    Returns:
-        A tuple containing the contents of the trigger file as a dictionary
-        and the S3 path of the zip file containing the latest source code.
-    """
-    data_from_s3_key = extract_data_from_s3_key(s3_key)
-    gh_org, gh_repo, gh_branch, s3_filename = (
-        data_from_s3_key["gh_org"],
-        data_from_s3_key["gh_repo"],
-        data_from_s3_key["gh_branch"],
-        data_from_s3_key["s3_filename"],
-    )
-    if gh_branch not in allowed_branches:
-        logger.error("Branch '%s' is not allowed to trigger the pipeline", gh_branch)
-        raise ValueError()
-    s3_prefix = f"{gh_org}/{gh_repo}/branches/{gh_branch}"
-
-    expected_keys_in_trigger_file = [
-        "SHA",
-        "date",
-        "name_prefix",
-        "aws_repo_name",
-    ]
-    contents_of_trigger_file = read_json_from_s3(
-        s3_bucket, s3_key, expected_keys_in_trigger_file
-    )
-    aws_gh_repo = contents_of_trigger_file["aws_repo_name"]
-    if aws_gh_repo == gh_repo:
-        # Triggered by update to aws repo
-        logger.debug(
-            "Lambda was triggered by GitHub repository containing the main AWS set up '%s'",
-            gh_repo,
-        )
-        s3_path = f"s3://{s3_bucket}/{s3_prefix}/{contents_of_trigger_file['SHA']}.zip"
-        return contents_of_trigger_file, s3_path
-
-    # Triggered by update to an application repo (e.g., frontend, Docker, etc.).
-    # Need to read trigger-event.json belonging to aws-repo
-    logger.debug(
-        "Lambda was triggered by GitHub repository containing application code '%s'",
-        gh_repo,
-    )
-    s3_prefix_aws_repo = f"{gh_org}/{aws_gh_repo}/branches/master"
-    s3_key_aws_repo = f"{s3_prefix_aws_repo}/{s3_filename}"
-    logger.debug(
-        "Reading the trigger file belonging to the GitHub repository containing the main AWS set up '%s'",
-        aws_gh_repo,
-    )
-    contents_of_trigger_file = read_json_from_s3(
-        s3_bucket, s3_key_aws_repo, expected_keys_in_trigger_file
-    )
-    s3_path = f"s3://{s3_bucket}/{s3_prefix_aws_repo}/{contents_of_trigger_file['SHA']}.zip"
-    return contents_of_trigger_file, s3_path
-
-
-def start_pipeline_execution(pipeline_arn, execution_name, execution_input):
-    """Starts a pipeline execution.
-
-    Args:
-        pipeline_arn: The ARN of the pipeline that is to be executed.
-        execution_name: The name of the execution.
-        execution_input: The JSON input to the execution.
-    """
-    client = boto3.client("stepfunctions")
-    client.start_execution(
-        stateMachineArn=pipeline_arn,
-        name=execution_name,
-        input=execution_input,
-    )
-
-
 def lambda_handler(event, context):
     logger.info("Lambda started with input event '%s'", event)
 
-    service_account_id = (
-        boto3.client("sts").get_caller_identity().get("Account")
-    )
-
     allowed_branches = json.loads(os.environ["ALLOWED_BRANCHES"])
     region = os.environ["AWS_REGION"]
+    service_account_id = os.environ["SERVICE_ACCOUNT_ID"]
 
     cost_saving_mode = event.get("cost_saving_mode", False)
     toggling_cost_saving_mode = event.get("toggling_cost_saving_mode", False)
@@ -207,24 +125,60 @@ def lambda_handler(event, context):
             "Lambda was triggered by file 's3://%s/%s'", s3_bucket, s3_key
         )
 
-    (
-        contents_of_trigger_file,
-        s3_path_of_aws_repository_zip,
-    ) = get_trigger_file_and_s3_path(s3_bucket, s3_key, allowed_branches)
+    required_keys = [
+        "git_owner",
+        "git_repo",
+        "git_branch",
+        "git_owner",
+        "git_sha1",
+        "pipeline_name",
+        "deployment_repo",
+        "trigger_file",
+    ]
 
-    logger.info(
-        "Using source code location '%s'", s3_path_of_aws_repository_zip
+    trigger_file = read_json_from_s3(s3_bucket, s3_key, required_keys)
+    s3_prefix = (
+        f"{trigger_file['git_owner']}/{trigger_file['git_repo']}/branches/"
+        f"{trigger_file['git_branch']}"
     )
+    deployment_package = (
+        f"s3://{s3_bucket}/{s3_prefix}/{trigger_file['git_sha1']}.zip"
+    )
+    if trigger_file["git_repo"] != trigger_file["deployment_repo"]:
+        deployment_trigger_file = read_json_from_s3(
+            s3_bucket,
+            (
+                f"{s3_bucket}/{trigger_file['git_owner']}/"
+                f"{trigger_file['deployment_repo']}/branches/master/"
+                f"{trigger_file['trigger_file']}"
+            ),
+            required_keys,
+        )
+        deployment_package = (
+            f"{s3_bucket}/{trigger_file['git_owner']}/"
+            f"{trigger_file['deployment_repo']}/branches/master/"
+            f"{deployment_trigger_file['git_sha1']}.zip"
+        )
+    logger.info("Using source code location '%s'", deployment_package)
 
-    pipeline_arn = f"arn:aws:states:{region}:{service_account_id}:stateMachine:{contents_of_trigger_file['name_prefix']}-state-machine"
+    pipeline_arn = (
+        f"arn:aws:states:{region}:{service_account_id}:stateMachine:"
+        "{trigger_file['pipeline_name']}"
+    )
     execution_name = (
-        f"{contents_of_trigger_file['SHA']}-{time.strftime('%Y%m%d-%H%M%S')}"
+        f"{trigger_file['git_sha1']}-{time.strftime('%Y%m%d-%H%M%S')}"
     )
     execution_input = json.dumps(
         {
-            "content": s3_path_of_aws_repository_zip,
-            "cost_saving_mode": cost_saving_mode,
-            "toggling_cost_saving_mode": toggling_cost_saving_mode,
+            **trigger_file,
+            "deployment_package": deployment_package,
+            "content": deployment_package,
         }
     )
-    start_pipeline_execution(pipeline_arn, execution_name, execution_input)
+
+    client = boto3.client("stepfunctions")
+    client.start_execution(
+        stateMachineArn=pipeline_arn,
+        name=execution_name,
+        input=execution_input,
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -163,7 +163,7 @@ def lambda_handler(event, context):
 
     pipeline_arn = (
         f"arn:aws:states:{region}:{service_account_id}:stateMachine:"
-        "{trigger_file['pipeline_name']}"
+        f"{trigger_file['pipeline_name']}"
     )
     execution_name = (
         f"{trigger_file['git_sha1']}-{time.strftime('%Y%m%d-%H%M%S')}"

--- a/src/main.py
+++ b/src/main.py
@@ -3,50 +3,9 @@ import boto3
 import time
 import logging
 import os
-import re
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-
-def extract_data_from_s3_key(s3_key):
-    """Extracts various values from an S3 key.
-
-    Args:
-        s3_key: The S3 key of the file that triggered the pipeline.
-
-    Returns:
-        A dictionary containing the name of the GitHub organization, repository,
-        branch and S3 file, or an empty dictionary if none or only a subset
-        of these values could be extracted.
-
-    Raises:
-        ValueError: The input S3 key could not be reconstructed by using the
-            extracted values.
-    """
-    gh_org_symbols = r"\S+"
-    gh_repo_symbols = r"\S+"
-    gh_branch_symbols = r"\S+"
-    s3_filename_symbols = r"[a-zA-Z0-9_.-]+"
-    pattern = re.compile(
-        rf"(?P<gh_org>{gh_org_symbols})"
-        rf"/(?P<gh_repo>{gh_repo_symbols})"
-        rf"/branches"
-        rf"/(?P<gh_branch>{gh_branch_symbols})"
-        rf"/(?P<s3_filename>{s3_filename_symbols})$"
-    )
-    m = pattern.match(s3_key)
-    groups = m.groupdict() if m else {}
-    if groups:
-        reconstructed_s3_key = f"{groups['gh_org']}/{groups['gh_repo']}/branches/{groups['gh_branch']}/{groups['s3_filename']}"
-        if reconstructed_s3_key != s3_key:
-            logger.error(
-                "Reconstructed S3 key '%s' is not equal to original S3 key '%s'",
-                reconstructed_s3_key,
-                s3_key,
-            )
-            raise ValueError()
-    return groups
 
 
 def read_json_from_s3(s3_bucket, s3_key, expected_keys=[]):

--- a/src/main.py
+++ b/src/main.py
@@ -183,8 +183,9 @@ def lambda_handler(event, context):
         logger.info("Verifying rules %s", trigger_rules)
         rule = next(
             (
-                rule["state_machine_arn"] == pipeline_arn
+                rule
                 for rule in trigger_rules
+                if rule["state_machine_arn"] == pipeline_arn
             ),
             None,
         )

--- a/src/main.py
+++ b/src/main.py
@@ -146,7 +146,7 @@ def lambda_handler(event, context):
         deployment_trigger_file = read_json_from_s3(
             s3_bucket,
             (
-                f"{s3_bucket}/{trigger_file['git_owner']}/"
+                f"{trigger_file['git_owner']}/"
                 f"{trigger_file['deployment_repo']}/branches/"
                 f"{trigger_file['deployment_branch']}/"
                 f"{name_of_trigger_file}"

--- a/src/main.py
+++ b/src/main.py
@@ -190,8 +190,8 @@ def lambda_handler(event, context):
         verified = verify_rule(
             rule,
             pipeline_arn,
-            trigger_file["git_repo"],
             trigger_file["git_branch"],
+            trigger_file["git_repo"],
         )
         if not verified:
             raise ValueError

--- a/src/main.py
+++ b/src/main.py
@@ -147,14 +147,16 @@ def lambda_handler(event, context):
             s3_bucket,
             (
                 f"{s3_bucket}/{trigger_file['git_owner']}/"
-                f"{trigger_file['deployment_repo']}/branches/master/"
+                f"{trigger_file['deployment_repo']}/branches/"
+                f"{trigger_file['deployment_branch']}/"
                 f"{name_of_trigger_file}"
             ),
             required_keys,
         )
         deployment_package = (
             f"{s3_bucket}/{trigger_file['git_owner']}/"
-            f"{trigger_file['deployment_repo']}/branches/master/"
+            f"{trigger_file['deployment_repo']}/branches/"
+            f"{trigger_file['deployment_branch']}/"
             f"{deployment_trigger_file['git_sha1']}.zip"
         )
     logger.info("Using source code location '%s'", deployment_package)

--- a/src/main.py
+++ b/src/main.py
@@ -115,7 +115,7 @@ def lambda_handler(event, context):
             s3_bucket,
             s3_key,
         )
-        additional_inputs = event["inputs"]
+        additional_inputs = event.get("inputs", {})
     else:
         triggered_by_ci = True
         s3_bucket = event["Records"][0]["s3"]["bucket"]["name"]

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "name_prefix" {
 }
 
 variable "allowed_branches" {
-  description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: A rule specified in `var.trigger_rules` takes presedence over this)."
+  description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: Rules specified in `var.trigger_rules` will override this for the pipelines in question)."
   default     = ["master"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "name_prefix" {
   type        = string
 }
 
-variable "statemachine_arn" {
-  description = "The ARN of the state machhine this lambda can trigger"
-  type        = string
-}
-
 variable "allowed_branches" {
   description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: A rule specified in `var.trigger_rules` takes presedence over this)."
   default     = ["master"]
@@ -23,9 +18,8 @@ variable "trigger_rules" {
   default = null
 }
 
-variable "additional_state_machine_arns" {
-  description = "A list of ARNs of additional state machines that the Lambda can trigger"
-  default     = []
+variable "state_machine_arns" {
+  description = "A list of ARNs of AWS Step Functions state machines that the Lambda can trigger."
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,18 +9,18 @@ variable "statemachine_arn" {
 }
 
 variable "allowed_branches" {
-  description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: `var.trigger_rules` takes presedence over this)."
+  description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: A rule specified in `var.trigger_rules` takes presedence over this)."
   default     = ["master"]
 }
 
 variable "trigger_rules" {
   description = "A list of objects that describe which branches and repositories are allowed to trigger a AWS Step Functions pipeline. A single wildcard item can be used to signify all (i.e., no restrictions)."
   type = list(object({
-    state_machine_arn = string
-    allowed_branches = list(string)
+    state_machine_arn    = string
+    allowed_branches     = list(string)
     allowed_repositories = list(string)
-  })
-  default     = null
+  }))
+  default = null
 }
 
 variable "additional_state_machine_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,18 @@ variable "statemachine_arn" {
 }
 
 variable "allowed_branches" {
-  description = "The branches that are allowed to trigger an AWS Step Functions pipeline."
+  description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: `var.trigger_rules` takes presedence over this)."
   default     = ["master"]
+}
+
+variable "trigger_rules" {
+  description = "A list of objects that describe which branches and repositories are allowed to trigger a AWS Step Functions pipeline. A single wildcard item can be used to signify all (i.e., no restrictions)."
+  type = list(object({
+    state_machine_arn = string
+    allowed_branches = list(string)
+    allowed_repositories = list(string)
+  })
+  default     = null
 }
 
 variable "additional_state_machine_arns" {


### PR DESCRIPTION
- Add support for per-state machine trigger rules that can control which branches and repositories can trigger the pipeline.
- Rely on contents of `trigger-event.json` instead of manually parsing the S3 key.
- Remove unused code.

## Breaking changes
- The variables `var.statemachine_arn` and `var.additional_state_machine_arns` have been replaced with a variable `var.state_machine_arns`.
- Relies on the new `trigger-event.json` format in the CircleCI orb.
- When triggered by a CloudWatch Event Rule, the input Lambda event needs to have the keys `eventbridge_rule`, `s3_key` and `s3_bucket`.
- Renames `content` to `deployment_package`
