### PR TITLE
Backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
-## Trigger Pipeline
+# terraform-aws-trigger-pipeline
+Terraform module that creates a Lambda function that can be used to bridge together a continuous integration (CI) service and an AWS Step Functions state machine.
 
-This template deploys a lambda based setup that trigger an step function pipline based on configuration parses from an s3 upload.
+The CI service uploads a JSON file to S3, which is then read by the Lambda to determine which state machine to trigger with which input.

--- a/policies.tf
+++ b/policies.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "logs_for_lambda" {
 data "aws_iam_policy_document" "s3_for_lambda" {
   statement {
     effect    = "Allow"
-    actions   = ["s3:GetObject"]
+    actions   = ["s3:GetObject", "s3:GetObjectVersion"]
     resources = ["${data.aws_s3_bucket.trigger_bucket.arn}/*"]
   }
 }

--- a/src/main.py
+++ b/src/main.py
@@ -239,7 +239,7 @@ def lambda_handler(event, context):
             legacy_keys=legacy_keys,
         )
         deployment_package = (
-            f"{s3_bucket}/{trigger_file['git_owner']}/"
+            f"s3://{s3_bucket}/{trigger_file['git_owner']}/"
             f"{trigger_file['deployment_repo']}/branches/"
             f"{trigger_file['deployment_branch']}/"
             f"{deployment_trigger_file['git_sha1']}.zip"

--- a/src/main.py
+++ b/src/main.py
@@ -200,7 +200,9 @@ def lambda_handler(event, context):
             "git_user": None,
             "git_sha1": trigger_file["SHA"],
             "deployment_repo": trigger_file["aws_repo_name"],
-            "deployment_branch": "master",
+            "deployment_branch": extracted_data["gh_branch"]
+            if extracted_data["gh_repo"] == trigger_file["aws_repo_name"]
+            else "master",
             "pipeline_name": f"{trigger_file['name_prefix']}-state-machine",
         }
 

--- a/src/main.py
+++ b/src/main.py
@@ -209,7 +209,10 @@ def lambda_handler(event, context):
         s3_version_id=s3_version_id,
     )
     trigger_file = get_parsed_trigger_file(
-        trigger_file, s3_key, required_keys, legacy_keys=legacy_keys
+        trigger_file,
+        s3_key,
+        expected_keys=required_keys,
+        legacy_keys=legacy_keys,
     )
 
     s3_prefix = (
@@ -220,17 +223,20 @@ def lambda_handler(event, context):
         f"s3://{s3_bucket}/{s3_prefix}/{trigger_file['git_sha1']}.zip"
     )
     if trigger_file["git_repo"] != trigger_file["deployment_repo"]:
+        deployment_s3_key = (
+            f"{trigger_file['git_owner']}/"
+            f"{trigger_file['deployment_repo']}/branches/"
+            f"{trigger_file['deployment_branch']}/"
+            f"{name_of_trigger_file}"
+        )
         deployment_trigger_file = read_json_from_s3(
-            s3_bucket,
-            (
-                f"{trigger_file['git_owner']}/"
-                f"{trigger_file['deployment_repo']}/branches/"
-                f"{trigger_file['deployment_branch']}/"
-                f"{name_of_trigger_file}"
-            ),
+            s3_bucket, deployment_s3_key
         )
         deployment_trigger_file = get_parsed_trigger_file(
-            deployment_trigger_file, required_keys, legacy_keys=legacy_keys
+            deployment_trigger_file,
+            deployment_s3_key,
+            expected_keys=required_keys,
+            legacy_keys=legacy_keys,
         )
         deployment_package = (
             f"{s3_bucket}/{trigger_file['git_owner']}/"

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,43 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+def extract_data_from_s3_key(s3_key):
+    """Extracts various values from an S3 key.
+    Args:
+        s3_key: The S3 key of the file that triggered the pipeline.
+    Returns:
+        A dictionary containing the name of the GitHub organization, repository,
+        branch and S3 file, or an empty dictionary if none or only a subset
+        of these values could be extracted.
+    Raises:
+        ValueError: The input S3 key could not be reconstructed by using the
+            extracted values.
+    """
+    gh_org_symbols = r"\S+"
+    gh_repo_symbols = r"\S+"
+    gh_branch_symbols = r"\S+"
+    s3_filename_symbols = r"[a-zA-Z0-9_.-]+"
+    pattern = re.compile(
+        rf"(?P<gh_org>{gh_org_symbols})"
+        rf"/(?P<gh_repo>{gh_repo_symbols})"
+        rf"/branches"
+        rf"/(?P<gh_branch>{gh_branch_symbols})"
+        rf"/(?P<s3_filename>{s3_filename_symbols})$"
+    )
+    m = pattern.match(s3_key)
+    groups = m.groupdict() if m else {}
+    if groups:
+        reconstructed_s3_key = f"{groups['gh_org']}/{groups['gh_repo']}/branches/{groups['gh_branch']}/{groups['s3_filename']}"
+        if reconstructed_s3_key != s3_key:
+            logger.error(
+                "Reconstructed S3 key '%s' is not equal to original S3 key '%s'",
+                reconstructed_s3_key,
+                s3_key,
+            )
+            raise ValueError()
+    return groups
+
+
 def read_json_from_s3(s3_bucket, s3_key, expected_keys=[]):
     """Reads the content of a JSON file in S3.
 

--- a/src/main.py
+++ b/src/main.py
@@ -62,10 +62,10 @@ def read_json_from_s3(s3_bucket, s3_key, s3_version_id=None):
         json.decoder.JSONDecodeError: Could not read file as JSON.
     """
     logger.debug(
-        "Reading file 's3://%s/%s' (version '%s')",
+        "Reading file 's3://%s/%s' (%s)",
         s3_bucket,
         s3_key,
-        s3_version_id,
+        f"version '{s3_version_id}'" if s3_version_id else "latest version",
     )
     try:
         s3 = boto3.resource("s3")


### PR DESCRIPTION
This should've been done in the previous PR. But better late than never!

- Make the Lambda backwards-compatible with the old trigger-event format.
- Use S3 version id when reading the file from S3 to avoid potential issues with S3 eventual consistency.