### PR TITLE
Use default values for deployment repo and branch

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -127,8 +127,9 @@ def verify_rule(rule, repo, branch):
 def get_parsed_trigger_file(
     trigger_file, s3_key, expected_keys=[], legacy_keys=[]
 ):
-    """Check that trigger file has the correct keys, and potentially
-    fall back to a legacy format if the first set of keys are not present"""
+    """Check that trigger file has the correct keys, add default values,
+    and potentially fall back to a legacy format if the first set of
+    keys are not present"""
     if all(key in trigger_file for key in expected_keys):
         return {
             "deployment_repo": trigger_file["git_repo"],

--- a/src/main.py
+++ b/src/main.py
@@ -130,7 +130,11 @@ def get_parsed_trigger_file(
     """Check that trigger file has the correct keys, and potentially
     fall back to a legacy format if the first set of keys are not present"""
     if all(key in trigger_file for key in expected_keys):
-        return trigger_file
+        return {
+            "deployment_repo": trigger_file["git_repo"],
+            "deployment_branch": trigger_file["git_branch"],
+            **trigger_file,
+        }
     elif all(key in trigger_file for key in legacy_keys):
         logger.warn("Parsing trigger file using legacy format")
         extracted_data = extract_data_from_s3_key(s3_key)
@@ -200,7 +204,6 @@ def lambda_handler(event, context):
         "git_user",
         "git_sha1",
         "pipeline_name",
-        "deployment_repo",
     ]
 
     trigger_file = read_json_from_s3(


### PR DESCRIPTION
- Use the triggering repository and branch as deployment repository and branch by default.

(The deployment repository and branch determine which ZIP file to input to the AWS Step Functions state machine execution, e.g., `{ "deployment_package": "s3://<bucket>/<owner>/<deployment-repo>/branches/<deployment-branch>/<sha1>.zip" }`).

This means that you don't need to include `deployment_repo` and `deployment_branch` in `trigger-event.json` if you are triggering an AWS Step Functions state machine with the contents of the current repository.

The minimal content of `trigger-event.json` is then:
```json
{
  "pipeline_name": "<state-machine-name>",
  "git_owner": "<owner>",
  "git_repo": "<repo>",
  "git_branch":"<branch>",
  "git_sha1": "<sha1>"
}
```

## Breaking changes
- None
