### PR TITLE
Add 'content' key to make execution input backwards-compatible

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -273,6 +273,7 @@ def lambda_handler(event, context):
                 else {}
             ),
             "deployment_package": deployment_package,
+            "content": deployment_package,
         },
         sort_keys=True,
     )


### PR DESCRIPTION
The `content` key have previously been renamed to `deployment_package`. The `content` key is, however, referenced in older state machine definitions.

This PR adds the key back to make the Lambda backwards-compatible with older AWS Step Functions deployment pipelines. We can phase it out at a later time. 