### PR TITLE
Store Lambda configuration in local file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "infra_trigger_pipeline" {
   role             = aws_iam_role.lambda_infra_trigger_pipeline_exec.arn
   runtime          = "python3.7"
   filename         = data.archive_file.this.output_path
-  source_code_hash = filebase64sha256(data.archive_file.this.output_path)
+  source_code_hash = data.archive_file.this.output_base64sha256
   timeout          = var.lambda_timeout
   tags             = var.tags
 }

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,11 @@ import re
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+# Read config file outside Lambda handler to allow reuse
+# between executions
+with open("config.json") as f:
+    CONFIG = json.load(f)
+
 
 def extract_data_from_s3_key(s3_key):
     """Extracts various values from an S3 key.
@@ -162,11 +167,10 @@ def get_parsed_trigger_file(
 
 def lambda_handler(event, context):
     logger.info("Lambda started with input event '%s'", event)
-
-    trigger_rules = json.loads(os.environ["TRIGGER_RULES"])
-    name_of_trigger_file = os.environ["NAME_OF_TRIGGER_FILE"]
+    trigger_rules = CONFIG["trigger_rules"]
+    name_of_trigger_file = CONFIG["name_of_trigger_file"]
+    service_account_id = CONFIG["current_account_id"]
     region = os.environ["AWS_REGION"]
-    service_account_id = os.environ["CURRENT_ACCOUNT_ID"]
     state_machine_arns = list(
         map(lambda rule: rule["state_machine_arn"], trigger_rules)
     )

--- a/src/main.py
+++ b/src/main.py
@@ -262,9 +262,6 @@ def lambda_handler(event, context):
         f"arn:aws:states:{region}:{service_account_id}:stateMachine:"
         f"{trigger_file['pipeline_name']}"
     )
-    if pipeline_arn not in state_machine_arns:
-        logger.error("Unexpected state machine ARN '%s'", state_machine_arns)
-        return
 
     execution_name = (
         f"{deployment_package_sha1}-{time.strftime('%Y%m%d-%H%M%S')}"
@@ -293,10 +290,9 @@ def lambda_handler(event, context):
             None,
         )
         if not rule:
-            logger.error(
+            logger.warn(
                 "No trigger rule found for state machine '%s'", pipeline_arn
             )
-            raise ValueError
         else:
             verified = verify_rule(
                 rule,

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "name_prefix" {
 
 variable "allowed_branches" {
   description = "The branches that are allowed to trigger an AWS Step Functions pipeline (NOTE: Rules specified in `var.trigger_rules` will override this for the pipelines in question)."
-  default     = ["master"]
+  default     = ["master", "main"]
 }
 
 variable "trigger_rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,13 +9,16 @@ variable "allowed_branches" {
 }
 
 variable "trigger_rules" {
-  description = "A list of objects that describe which branches and repositories are allowed to trigger a AWS Step Functions pipeline. A single wildcard item can be used to signify all (i.e., no restrictions)."
-  type = list(object({
-    state_machine_arn    = string
-    allowed_branches     = list(string)
-    allowed_repositories = list(string)
-  }))
-  default = null
+  description = <<DOC
+An optional list of objects that describe which branches and repositories are allowed to trigger an AWS Step Functions state machine.
+
+Object fields:
+state_machine_arn: The ARN of the state machine that the rule is valid for.
+allowed_branches: Optional list of branches that can trigger the state machine (defaults to the value of `var.allowed_branches`). A single wildcard item can be used to signify all.
+allowed_repositories: Optional list of GitHub repositories that can trigger the state machine (defaults to ["*"]). A single wildcard item can be used to signify all.
+DOC
+  type        = list
+  default     = []
 }
 
 variable "state_machine_arns" {


### PR DESCRIPTION
## Context
We currently pass in various values to the Lambda function as environment variables. Environment variables are, however, capped at 4KB, and an account with many AWS Step Functions pipelines may get close to this limit.

We can instead store the configuration in a separate file, bundle it together with the Lambda and read the configuration at runtime. Opening and reading the file outside of the Lambda handler should furthermore allow re-use between Lambda executions. As such, there should be no major drawbacks by using this approach, and it allows us to freely store configuration without worrying about potential environment variable limits. Preliminary testing shows that the execution time is roughly the same (500 - 2000ms) as when using environment variables.

## Changes
This PR stores various configuration values for the Lambda in a separate JSON file that is bundled with the deployment package, and read by the Lambda at runtime.

Additionally, default values for which GitHub branches can trigger pipelines are also updated (`master` and `main`), and default values for trigger rules are added.

## Breaking Changes
None