### PR TITLE
Use more explicit and stricter types in input variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,10 @@ locals {
   }
   trigger_rules_by_pipeline = var.trigger_rules == [] ? {} : { for obj in var.trigger_rules : obj.state_machine_arn => {
     state_machine_arn    = obj.state_machine_arn
-    allowed_branches     = lookup(obj, "allowed_branches", var.allowed_branches)
-    allowed_repositories = lookup(obj, "allowed_repositories", var.allowed_repositories)
-  } }
+    allowed_branches     = obj.allowed_branches
+    allowed_repositories = obj.allowed_repositories
+    }
+  }
   trigger_rules = [for arn in var.state_machine_arns : lookup(local.trigger_rules_by_pipeline, arn, {
     state_machine_arn    = arn
     allowed_branches     = var.allowed_branches

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,13 @@ variable "name_prefix" {
 variable "allowed_branches" {
   description = "A list of GitHub branches that are allowed to trigger an AWS Step Functions pipeline. A single wildcard item can be used to signify all. (NOTE: Rules specified in `var.trigger_rules` will override this for the pipelines in question)."
   default     = ["master", "main"]
+  type        = list(string)
 }
 
 variable "allowed_repositories" {
   description = "A list of GitHub repositories (e.g., `nsbno/my-repository`) that are allowed to trigger an AWS Step Functions pipeline. A single wildcard item can be used to signify all. (NOTE: Rules specified in `var.trigger_rules` will override this for the pipelines in question)."
   default     = ["*"]
+  type        = list(string)
 }
 
 variable "trigger_rules" {
@@ -19,11 +21,15 @@ An optional list of objects that describe which branches and repositories are al
 
 Object fields:
 state_machine_arn: The ARN (without wildcards) of the state machine that the rule is valid for.
-allowed_branches: Optional list of branches that can trigger the state machine (defaults to the value of `var.allowed_branches`). A single wildcard item can be used to signify all.
-allowed_repositories: Optional list of GitHub repositories that can trigger the state machine (defaults to ["*"]). A single wildcard item can be used to signify all.
+allowed_branches: A list of branches that can trigger the state machine. A single wildcard item can be used to signify all.
+allowed_repositories: A list of GitHub repositories that can trigger the state machine. A single wildcard item can be used to signify all.
 DOC
-  type        = list(any)
-  default     = []
+  type = list(object({
+    state_machine_arn    = string
+    allowed_branches     = list(string)
+    allowed_repositories = list(string)
+  }))
+  default = []
 }
 
 variable "state_machine_arns" {


### PR DESCRIPTION
Stricter type checking has been added to Terraform v0.13 that results in the module failing when a user of the module supplies `var.trigger_rules` on a version of Terraform >= v.0.13.

This PR introduces more explicit and stricter types for the input variables that fixes the issue.

Related upstream issues:
- https://github.com/hashicorp/terraform/issues/27509